### PR TITLE
Additional testcase

### DIFF
--- a/schema/postgresql/t/05-fill-hoststatus.sql
+++ b/schema/postgresql/t/05-fill-hoststatus.sql
@@ -2,6 +2,7 @@ SELECT plan(1);
 COPY icinga_hoststatus FROM STDIN;
 1	2019-02-10 12:00:00+01	0	1
 1	2019-03-10 15:00:00+01	1	1
+3	2019-03-10 16:15:00+01	1	1
 \.
 
-SELECT is(count(*), 2::bigint, 'icinga_hoststatus has 2 rows') FROM icinga_hoststatus;
+SELECT is(count(*), 3::bigint, 'icinga_hoststatus has 3 rows') FROM icinga_hoststatus;

--- a/schema/postgresql/t/05-fill-icinga_objects.sql
+++ b/schema/postgresql/t/05-fill-icinga_objects.sql
@@ -1,4 +1,5 @@
 SELECT plan(1);
 INSERT INTO icinga_objects VALUES (1,1);
 INSERT INTO icinga_objects VALUES (2,2);
-SELECT is(count(*), 2::bigint, 'icinga_objects has 2 rows') FROM icinga_objects;
+INSERT INTO icinga_objects VALUES (3,1);
+SELECT is(count(*), 3::bigint, 'icinga_objects has 3 rows') FROM icinga_objects;

--- a/schema/postgresql/t/05-fill-statehistory.sql
+++ b/schema/postgresql/t/05-fill-statehistory.sql
@@ -16,5 +16,7 @@ COPY icinga_statehistory FROM STDIN;
 2019-03-01 00:00:00+01	2	0	1
 2019-03-05 11:00:00+01	2	3	0
 2019-03-05 12:00:00+01	2	3	1
+2019-03-10 16:05:00+01	3	1	0
+2019-03-10 16:10:00+01	3	1	1
 \.
-SELECT is(count(*), 16::bigint, 'icinga_statehistory has 16 rows') FROM icinga_statehistory;
+SELECT is(count(*), 18::bigint, 'icinga_statehistory has 18 rows') FROM icinga_statehistory;

--- a/schema/postgresql/t/07-test-func.sql
+++ b/schema/postgresql/t/07-test-func.sql
@@ -1,4 +1,4 @@
-SELECT plan(20);
+SELECT plan(21);
 SELECT is(idoreports_get_sla_ok_percent(1,'2019-02-05 12:00', '2019-02-05 14:00')::float , 0.0::float,'Host 1 was down 2 out of 2 hours');
 SELECT is(idoreports_get_sla_ok_percent(1,'2019-02-05 10:00', '2019-02-05 14:00')::float , 50.0::float,'Host 1 was down 2 out of 4 hours');
 SELECT is(idoreports_get_sla_ok_percent(1,'2019-02-05 10:00', '2019-02-05 18:00')::float , 75.0::float,'Host 1 was down 2 out of 8 hours');
@@ -20,3 +20,5 @@ SELECT is(idoreports_get_sla_ok_percent(2,'2019-02-05 13:00', '2019-02-06 13:00'
 SELECT is(idoreports_get_sla_ok_percent(2,'2019-03-05 11:00', '2019-03-05 13:00')::float , 50.0::float,'Service 2 was down 1 out of 2 hours');
 SELECT is(idoreports_get_sla_ok_percent(2,'2019-03-05 12:00', '2019-03-05 13:00')::float , 0.0::float,'Service 2 was down during that period');
 SELECT is(idoreports_get_sla_ok_percent(2,'2019-03-05 13:00', '2019-03-05 14:00')::float , 0.0::float,'Service 2 was down during that period');
+
+SELECT is(idoreports_get_sla_ok_percent(3,'2019-03-10 17:00', '2019-03-11 00:00')::float , 0.0::float,'Host 3 was considered down for the rest of the day');


### PR DESCRIPTION
This testcase currently fails for me:

```
t/07-test-func.sql ................ 1/21 
# Failed test 21: "Host 3 was considered down for the rest of the day"
#         have: -10.714285714285722
#         want: 0
t/07-test-func.sql ................ Failed 1/21 subtests 
```

The data is based on some real-world data where I see this issue as well.